### PR TITLE
Ignore allowlisted login failures before banning

### DIFF
--- a/custom_components/ban_allowlist/__init__.py
+++ b/custom_components/ban_allowlist/__init__.py
@@ -3,11 +3,24 @@
 from __future__ import annotations
 
 import logging
-from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_network
+from ipaddress import (
+    IPv4Address,
+    IPv4Network,
+    IPv6Address,
+    IPv6Network,
+    ip_address,
+    ip_network,
+)
 from typing import List
 
 import voluptuous as vol
-from homeassistant.components.http.ban import KEY_BAN_MANAGER, IpBanManager
+from aiohttp.web import Request
+from homeassistant.components.http import ban as http_ban
+from homeassistant.components.http.ban import (
+    KEY_BAN_MANAGER,
+    KEY_FAILED_LOGIN_ATTEMPTS,
+    IpBanManager,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -33,7 +46,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     try:
         ban_manager: IpBanManager = hass.http.app[KEY_BAN_MANAGER]
     except KeyError:
-        _LOGGER.warn(
+        _LOGGER.warning(
             "Can't find ban manager. ban_allowlist requires http.ip_ban_enabled to be True, so disabling."
         )
         return True
@@ -46,18 +59,43 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     else:
         _LOGGER.info("Setting allowlist with %s", [str(ip) for ip in allowlist])
 
+        def is_allowed(remote_addr: IPv4Address | IPv6Address) -> bool:
+            return any(remote_addr in allowed_network for allowed_network in allowlist)
+
+        original_process_wrong_login = http_ban.process_wrong_login
+
+        async def allowlist_process_wrong_login(request: Request) -> None:
+            remote = request.remote
+            if remote is not None:
+                try:
+                    remote_addr = ip_address(remote)
+                except ValueError:
+                    remote_addr = None
+                if remote_addr is not None and is_allowed(remote_addr):
+                    attempts = request.app.get(KEY_FAILED_LOGIN_ATTEMPTS)
+                    if attempts is not None:
+                        attempts.pop(remote_addr, None)
+                    _LOGGER.info(
+                        "Ignoring invalid authentication from %s because it is in the allowlist",
+                        remote_addr,
+                    )
+                    return
+
+            await original_process_wrong_login(request)
+
+        http_ban.process_wrong_login = allowlist_process_wrong_login
+
         original_async_add_ban = IpBanManager.async_add_ban
 
         async def allowlist_async_add_ban(
             remote_addr: IPv4Address | IPv6Address,
         ) -> None:
-            for allowed_network in allowlist:
-                if remote_addr in allowed_network:
-                    _LOGGER.info(
-                        "Not adding %s to ban list, as it's in the allowlist",
-                        remote_addr,
-                    )
-                    return
+            if is_allowed(remote_addr):
+                _LOGGER.info(
+                    "Not adding %s to ban list, as it's in the allowlist",
+                    remote_addr,
+                )
+                return
 
             _LOGGER.info("Banning IP %s", remote_addr)
             await original_async_add_ban(ban_manager, remote_addr)

--- a/tests/ban_allowlist/test_setup.py
+++ b/tests/ban_allowlist/test_setup.py
@@ -1,11 +1,16 @@
 """Test Ban Allowlist setup."""
 
 import logging
-from ipaddress import IPv4Address
-from typing import cast
+from ipaddress import IPv4Address, ip_address
+from typing import Any, cast
 
 import pytest
-from homeassistant.components.http.ban import KEY_BAN_MANAGER, IpBanManager
+from homeassistant.components.http import ban as http_ban
+from homeassistant.components.http.ban import (
+    KEY_BAN_MANAGER,
+    KEY_FAILED_LOGIN_ATTEMPTS,
+    IpBanManager,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import DATA_CUSTOM_COMPONENTS, async_get_custom_components
 from homeassistant.setup import async_setup_component
@@ -80,4 +85,39 @@ async def test_hit_allowlist(
         "Banning IP 10.0.0.1",
         "Not adding 172.17.0.10 to ban list, as it's in the allowlist",
         "Banning IP 172.17.1.10",
+    ]
+
+
+@pytest.mark.anyio
+async def test_ignored_wrong_login_does_not_increment_attempts(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test allowlisted login failures don't count toward a ban."""
+    await setup_ban_allowlist(hass)
+
+    remote_addr = ip_address("192.168.1.1")
+    hass.http.app[KEY_FAILED_LOGIN_ATTEMPTS][remote_addr] = 1
+
+    class MockRequest:
+        remote = "192.168.1.1"
+        app = hass.http.app
+
+    await http_ban.process_wrong_login(cast(Any, MockRequest()))
+    check_records(caplog.records)
+
+    assert remote_addr not in hass.http.app[KEY_FAILED_LOGIN_ATTEMPTS]
+
+    messages = []
+
+    for record in caplog.records:
+        if record.levelno < logging.INFO or not record.name.startswith(
+            "custom_components.ban_allowlist"
+        ):
+            continue
+
+        messages.append(record.getMessage())
+
+    assert messages == [
+        "Setting allowlist with ['192.168.1.1/32', '172.17.0.0/24']",
+        "Ignoring invalid authentication from 192.168.1.1 because it is in the allowlist",
     ]


### PR DESCRIPTION
## Summary

Allowlisted IPs are now ignored before Home Assistant records a failed login attempt or creates login/ban persistent notifications.

`IpBanManager.async_add_ban` is still wrapped as before, but Home Assistant creates the failed-login notification path earlier in `process_wrong_login`. This patch short-circuits `process_wrong_login` for allowlisted IPs and clears any existing failed-attempt entry for that address.

## Validation

- `python -m py_compile custom_components/ban_allowlist/__init__.py tests/ban_allowlist/test_setup.py`
